### PR TITLE
fix #38: added support for WSL for turtlesim demo

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -29,7 +29,12 @@ DEVELOPMENT=${DEVELOPMENT:-false}
 case "$(uname)" in
     Linux*|Darwin*)
         echo "Enabling X11 forwarding..."
-        export DISPLAY=host.docker.internal:0
+        # If running under WSL, use :0 for DISPLAY
+        if grep -q "WSL" /proc/version; then
+            export DISPLAY=:0
+        else
+            export DISPLAY=host.docker.internal:0
+        fi
         xhost +
         ;;
     MINGW*|CYGWIN*|MSYS*)


### PR DESCRIPTION
## Purpose
Added support for WSL for turtlesim demo.

Using WSL, `host.docker.internal` resolver is not present inside `/etc/hosts` file of the linux distro. It's among dns resolver of windows, inside `C:\Windows\System32\drivers\etc\hosts`.
So export `DISPLAY=host.docker.internal:0` won't work. In that case, it will be used `export DISPLAY=:0`


## Issues
#38 

## Testing
- Tested on WSL 2
