### PR TITLE
added dependency caching for faster builds using buildkit

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -25,6 +25,8 @@ fi
 HEADLESS=${HEADLESS:-false}
 DEVELOPMENT=${DEVELOPMENT:-false}
 
+export DOCKER_BUILDKIT=1
+
 # Enable X11 forwarding based on OS
 case "$(uname)" in
     Linux*|Darwin*)
@@ -33,7 +35,7 @@ case "$(uname)" in
         if grep -q "WSL" /proc/version; then
             export DISPLAY=:0
         else
-            export DISPLAY=host.docker.internal:0
+            export DISPLAY=:1
         fi
         xhost +
         ;;
@@ -56,7 +58,7 @@ fi
 # Build and run the Docker container
 CONTAINER_NAME="rosa-turtlesim-demo"
 echo "Building the $CONTAINER_NAME Docker image..."
-docker build --build-arg DEVELOPMENT=$DEVELOPMENT -t $CONTAINER_NAME -f Dockerfile . || { echo "Error: Docker build failed"; exit 1; }
+docker build --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg DEVELOPMENT=$DEVELOPMENT -t $CONTAINER_NAME -f Dockerfile . || { echo "Error: Docker build failed"; exit 1; }
 
 echo "Running the Docker container..."
 docker run -it --rm --name $CONTAINER_NAME \


### PR DESCRIPTION
## Purpose
- Added dependency caching for .deb and pip packages for faster build times

## Proposed Changes
- [CHANGE] - Mounted cache `/var/cache/apt` and `/var/lib/apt` directories and used BUILDKIT to maintain and use cache while running docker

## Testing
- Build time without using caching: ~100s 
![image](https://github.com/user-attachments/assets/f15ae0a1-7213-4ee9-8e0a-c0fcfa66468e)
- Build time with caching: 
![image](https://github.com/user-attachments/assets/ab4db008-8037-42ee-9786-9407452d88de)
