### PR TITLE
fix: use Console().print for token usage and remove spurious space in…

### DIFF
--- a/src/rosa/rosa.py
+++ b/src/rosa/rosa.py
@@ -18,6 +18,7 @@ import logging
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, AsyncIterable, Dict, Literal, Optional, Union
 
+from rich.console import Console
 from langchain.agents import AgentExecutor, create_tool_calling_agent
 from langchain.prompts import MessagesPlaceholder
 from langchain_community.callbacks import get_openai_callback
@@ -216,7 +217,7 @@ class ROSA:
                     # Extract the content from the event and yield it
                     content = event["data"]["chunk"].content
                     if content:
-                        final_output += f" {content}"
+                        final_output += content
                         yield {"type": "token", "content": content}
 
                 # Handle tool start events
@@ -328,9 +329,9 @@ class ROSA:
         """Print the token usage if show_token_usage is enabled."""
         if cb is None or not self.__show_token_usage:
             return
-        print(f"[bold]Prompt Tokens:[/bold] {cb.prompt_tokens}")
-        print(f"[bold]Completion Tokens:[/bold] {cb.completion_tokens}")
-        print(f"[bold]Total Cost (USD):[/bold] ${cb.total_cost}")
+        Console().print(f"[bold]Prompt Tokens:[/bold] {cb.prompt_tokens}")
+        Console().print(f"[bold]Completion Tokens:[/bold] {cb.completion_tokens}")
+        Console().print(f"[bold]Total Cost (USD):[/bold] ${cb.total_cost}")
 
     def _record_chat_history(self, query: str, response: str):
         """Record the chat history if accumulation is enabled."""


### PR DESCRIPTION
Fixes #75

Two bugs in src/rosa/rosa.py are fixed in this PR.

## Purpose

_print_usage was calling print() with rich markup strings. Plain print() does not interpret rich markup, so show_token_usage=True printed literal bracket tags instead of formatted text. Replaced with Console().print() and added the missing Console import from rich.console.

In astream, the token accumulation read final_output += f" {content}", prepending a space before every token. When no on_chain_end event provides a final output, the fallback string recorded to chat history started with a leading space. Changed to final_output += content.

## Proposed Changes

- [FIX] _print_usage: replaced print() with Console().print() so rich markup renders correctly
- [ADD] from rich.console import Console
- [FIX] astream: removed spurious leading space in token accumulation

## Issues

- Fixes #75

## Testing

- Verified _print_usage with show_token_usage=True renders bold labels correctly in terminal
- Verified astream chat history entries no longer start with a leading space
- No existing tests broken