### PR TITLE
Add support for NVIDIA NIM as an LLM provider

### DIFF
--- a/.env
+++ b/.env
@@ -17,5 +17,5 @@ OLLAMA_BASE_URL=http://localhost:11434
 
 # NVIDIA NIM Configuration
 NVIDIA_API_KEY=
-NVIDIA_MODEL=nvidia/llama-3.3-nemotron-super-49b-v1
+NVIDIA_MODEL=nvidia/llama-3.1-nemotron-ultra-253b-v1
 NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1

--- a/.env
+++ b/.env
@@ -17,5 +17,5 @@ OLLAMA_BASE_URL=http://localhost:11434
 
 # NVIDIA NIM Configuration
 NVIDIA_API_KEY=
-NVIDIA_MODEL=nvidia/nemotron-3-super-120b-a12b
+NVIDIA_MODEL=nvidia/llama-3.3-nemotron-super-49b-v1
 NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1

--- a/.env
+++ b/.env
@@ -17,5 +17,5 @@ OLLAMA_BASE_URL=http://localhost:11434
 
 # NVIDIA NIM Configuration
 NVIDIA_API_KEY=
-NVIDIA_MODEL=nvidia/llama-3.1-nemotron-ultra-253b-v1
+NVIDIA_MODEL=nvidia/nemotron-3-super-120b-a12b
 NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1

--- a/.env
+++ b/.env
@@ -17,5 +17,5 @@ OLLAMA_BASE_URL=http://localhost:11434
 
 # NVIDIA NIM Configuration
 NVIDIA_API_KEY=
-NVIDIA_MODEL=nvidia/nemotron-3-super-120b-a12b
+NVIDIA_MODEL=nvidia/llama-3.3-nemotron-super-49b-v1.5
 NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-# LLM Provider: "openai" (default), "anthropic", or "ollama"
+# LLM Provider: "openai" (default), "anthropic", "nvidia", or "ollama"
 LLM_PROVIDER=openai
 
 # OpenAI Configuration
@@ -14,3 +14,8 @@ ANTHROPIC_MODEL=claude-sonnet-4-5
 # Ollama Configuration (local models)
 OLLAMA_MODEL=llama3
 OLLAMA_BASE_URL=http://localhost:11434
+
+# NVIDIA NIM Configuration
+NVIDIA_API_KEY=
+NVIDIA_MODEL=nvidia/nemotron-3-super-120b-a12b
+NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,9 @@ dependencies = [
 
 [project.optional-dependencies]
 anthropic = ["langchain-anthropic~=0.3.12"]
+nvidia = ["langchain-nvidia-ai-endpoints~=0.3.9"]
 ollama = ["langchain-ollama~=0.3.2"]
-all = ["langchain-anthropic~=0.3.12", "langchain-ollama~=0.3.2"]
+all = ["langchain-anthropic~=0.3.12", "langchain-nvidia-ai-endpoints~=0.3.9", "langchain-ollama~=0.3.2"]
 
 [project.urls]
 "Homepage" = "https://github.com/nasa-jpl/rosa"

--- a/src/rosa/rosa.py
+++ b/src/rosa/rosa.py
@@ -28,6 +28,7 @@ from langchain_openai import AzureChatOpenAI, ChatOpenAI
 
 if TYPE_CHECKING:
     from langchain_anthropic import ChatAnthropic
+    from langchain_nvidia_ai_endpoints import ChatNVIDIA
     from langchain_ollama import ChatOllama
 
 from .prompts import RobotSystemPrompts, system_prompts
@@ -37,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 # Tested providers for static analysis; BaseChatModel accepted at runtime.
 if TYPE_CHECKING:
-    ChatModel = Union[ChatOpenAI, AzureChatOpenAI, ChatAnthropic, ChatOllama]
+    ChatModel = Union[ChatOpenAI, AzureChatOpenAI, ChatAnthropic, ChatNVIDIA, ChatOllama]
 else:
     ChatModel = BaseChatModel
 
@@ -49,7 +50,7 @@ class ROSA:
     Args:
         ros_version (Literal[1, 2]): The version of ROS that the agent will interact with.
         llm (ChatModel): The language model to use for generating responses. Tested providers:
-            ChatOpenAI, AzureChatOpenAI, ChatAnthropic, and ChatOllama. Other BaseChatModel
+            ChatOpenAI, AzureChatOpenAI, ChatAnthropic, ChatNVIDIA, and ChatOllama. Other BaseChatModel
             subclasses that support tool calling may work but are not officially tested.
             Note: token usage tracking is only supported for ChatOpenAI and AzureChatOpenAI.
         tools (Optional[list]): A list of additional LangChain tool functions to use with the agent.

--- a/src/turtle_agent/scripts/llm.py
+++ b/src/turtle_agent/scripts/llm.py
@@ -59,11 +59,10 @@ def get_llm(streaming: bool = False):
     elif provider == "nvidia":
         try:
             from langchain_nvidia_ai_endpoints import ChatNVIDIA
-        except ImportError:
+        except ImportError as e:
             raise ImportError(
-                "langchain-nvidia-ai-endpoints is required for NVIDIA NIM support. "
-                "Install the project's NVIDIA extra with: pip install '.[nvidia]'"
-            )
+                "Install the project's NVIDIA extra with: pip install 'jpl-rosa[nvidia]'"
+            ) from e
         llm = ChatNVIDIA(
             api_key=get_env_variable("NVIDIA_API_KEY"),
             model=os.getenv("NVIDIA_MODEL", "nvidia/nemotron-3-super-120b-a12b"),
@@ -109,4 +108,4 @@ def get_env_variable(var_name: str) -> str:
     if not value or not value.strip():
         msg = f"Environment variable {var_name} is not set."
         raise ValueError(msg)
-    return value
+    return value.strip()

--- a/src/turtle_agent/scripts/llm.py
+++ b/src/turtle_agent/scripts/llm.py
@@ -21,16 +21,17 @@ from langchain_openai import ChatOpenAI
 def get_llm(streaming: bool = False):
     """A helper function to get the LLM instance.
 
-    Supports OpenAI (default), Anthropic and Ollama models.
+    Supports OpenAI (default), Anthropic, NVIDIA NIM and Ollama models.
     Set the LLM_PROVIDER env variable to switch between providers:
       - "openai" (default): uses OPENAI_API_KEY
       - "anthropic": uses ANTHROPIC_API_KEY
+      - "nvidia": uses NVIDIA_API_KEY (NIM API)
       - "ollama": uses local Ollama instance
     """
     dotenv.load_dotenv(dotenv.find_dotenv())
 
     provider = os.getenv("LLM_PROVIDER", "openai").lower().strip()
-    supported = ("openai", "anthropic", "ollama")
+    supported = ("openai", "anthropic", "nvidia", "ollama")
     if provider not in supported:
         raise ValueError(
             f"Unknown LLM_PROVIDER: '{provider}'. Must be one of: {', '.join(supported)}"
@@ -53,6 +54,20 @@ def get_llm(streaming: bool = False):
         llm = ChatAnthropic(
             api_key=get_env_variable("ANTHROPIC_API_KEY"),
             model=os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-5"),
+            streaming=streaming,
+        )
+    elif provider == "nvidia":
+        try:
+            from langchain_nvidia_ai_endpoints import ChatNVIDIA
+        except ImportError:
+            raise ImportError(
+                "langchain-nvidia-ai-endpoints is required for NVIDIA NIM support. "
+                "Install it with: pip install langchain-nvidia-ai-endpoints"
+            )
+        llm = ChatNVIDIA(
+            api_key=get_env_variable("NVIDIA_API_KEY"),
+            model=os.getenv("NVIDIA_MODEL", "nvidia/nemotron-3-super-120b-a12b"),
+            base_url=os.getenv("NVIDIA_BASE_URL", "https://integrate.api.nvidia.com/v1"),
             streaming=streaming,
         )
     elif provider == "ollama":

--- a/src/turtle_agent/scripts/llm.py
+++ b/src/turtle_agent/scripts/llm.py
@@ -66,7 +66,7 @@ def get_llm(streaming: bool = False):
             )
         llm = ChatNVIDIA(
             api_key=get_env_variable("NVIDIA_API_KEY"),
-            model=os.getenv("NVIDIA_MODEL", "nvidia/nemotron-3-super-120b-a12b"),
+            model=os.getenv("NVIDIA_MODEL", "nvidia/llama-3.3-nemotron-super-49b-v1"),
             base_url=os.getenv("NVIDIA_BASE_URL", "https://integrate.api.nvidia.com/v1"),
             streaming=streaming,
         )

--- a/src/turtle_agent/scripts/llm.py
+++ b/src/turtle_agent/scripts/llm.py
@@ -66,7 +66,7 @@ def get_llm(streaming: bool = False):
             )
         llm = ChatNVIDIA(
             api_key=get_env_variable("NVIDIA_API_KEY"),
-            model=os.getenv("NVIDIA_MODEL", "nvidia/llama-3.3-nemotron-super-49b-v1"),
+            model=os.getenv("NVIDIA_MODEL", "nvidia/llama-3.1-nemotron-ultra-253b-v1"),
             base_url=os.getenv("NVIDIA_BASE_URL", "https://integrate.api.nvidia.com/v1"),
             streaming=streaming,
         )

--- a/src/turtle_agent/scripts/llm.py
+++ b/src/turtle_agent/scripts/llm.py
@@ -66,7 +66,7 @@ def get_llm(streaming: bool = False):
             )
         llm = ChatNVIDIA(
             api_key=get_env_variable("NVIDIA_API_KEY"),
-            model=os.getenv("NVIDIA_MODEL", "nvidia/llama-3.1-nemotron-ultra-253b-v1"),
+            model=os.getenv("NVIDIA_MODEL", "nvidia/nemotron-3-super-120b-a12b"),
             base_url=os.getenv("NVIDIA_BASE_URL", "https://integrate.api.nvidia.com/v1"),
             streaming=streaming,
         )

--- a/src/turtle_agent/scripts/llm.py
+++ b/src/turtle_agent/scripts/llm.py
@@ -65,7 +65,7 @@ def get_llm(streaming: bool = False):
             ) from e
         llm = ChatNVIDIA(
             api_key=get_env_variable("NVIDIA_API_KEY"),
-            model=os.getenv("NVIDIA_MODEL", "nvidia/nemotron-3-super-120b-a12b"),
+            model=os.getenv("NVIDIA_MODEL", "nvidia/llama-3.3-nemotron-super-49b-v1.5"),
             base_url=os.getenv("NVIDIA_BASE_URL", "https://integrate.api.nvidia.com/v1"),
             streaming=streaming,
         )

--- a/src/turtle_agent/scripts/llm.py
+++ b/src/turtle_agent/scripts/llm.py
@@ -62,7 +62,7 @@ def get_llm(streaming: bool = False):
         except ImportError:
             raise ImportError(
                 "langchain-nvidia-ai-endpoints is required for NVIDIA NIM support. "
-                "Install it with: pip install langchain-nvidia-ai-endpoints"
+                "Install the project's NVIDIA extra with: pip install '.[nvidia]'"
             )
         llm = ChatNVIDIA(
             api_key=get_env_variable("NVIDIA_API_KEY"),
@@ -106,7 +106,7 @@ def get_env_variable(var_name: str) -> str:
     raise a ValueError, making it easier to debug configuration issues.
     """
     value = os.getenv(var_name)
-    if value is None:
+    if not value or not value.strip():
         msg = f"Environment variable {var_name} is not set."
         raise ValueError(msg)
     return value


### PR DESCRIPTION
Adds NVIDIA NIM support. Uses `langchain-nvidia-ai-endpoints` with `ChatNVIDIA`. Backwards compatible.

```bash
LLM_PROVIDER=nvidia NVIDIA_API_KEY=nvapi-... python turtle_agent.py
```
