### PR TITLE
feat: add tool_modules parameter for selective built-in module loading

### DIFF
--- a/src/rosa/rosa.py
+++ b/src/rosa/rosa.py
@@ -93,6 +93,7 @@ class ROSA:
         streaming: bool = True,
         max_iterations: int = 100,
         return_intermediate_steps: bool = False,
+        tool_modules: Optional[set] = None,  # add this
     ):
         self.__chat_history = []
         self.__ros_version = ros_version
@@ -105,7 +106,7 @@ class ROSA:
         self.__max_iterations = max_iterations
         self.__return_intermediate_steps = return_intermediate_steps
         self.__tools = self._get_tools(
-            ros_version, packages=tool_packages, tools=tools, blacklist=self.__blacklist
+            ros_version, packages=tool_packages, tools=tools, blacklist=self.__blacklist, tool_modules=tool_modules
         )
         self.__prompts = self._get_prompts(prompts)
         self.__agent = self._get_agent()
@@ -281,9 +282,9 @@ class ROSA:
         packages: Optional[list],
         tools: Optional[list],
         blacklist: Optional[list],
+        tool_modules: Optional[set],
     ) -> ROSATools:
-        """Create a ROSA tools object with the specified ROS version, tools, packages, and blacklist."""
-        rosa_tools = ROSATools(ros_version, blacklist=blacklist)
+        rosa_tools = ROSATools(ros_version, blacklist=blacklist, tool_modules=tool_modules)
         if tools:
             rosa_tools.add_tools(tools)
         if packages:

--- a/src/rosa/rosa.py
+++ b/src/rosa/rosa.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, AsyncIterable, Dict, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, AsyncIterable, Dict, Literal, Optional, Set, Union
 
 from langchain.agents import AgentExecutor, create_tool_calling_agent
 from langchain.prompts import MessagesPlaceholder
@@ -61,8 +61,22 @@ class ROSA:
         show_token_usage (bool): Whether to show token usage. Does not work when streaming is enabled. Defaults to False.
         streaming (bool): Whether to stream the output of the agent. Defaults to True.
         max_iterations (int): Maximum number of iterations for the agent executor. Defaults to 100.
-        return_intermediate_steps (bool): Whether to return intermediate steps in the agent's execution. 
+        return_intermediate_steps (bool): Whether to return intermediate steps in the agent's execution.
             Setting to True increases memory usage but provides detailed execution traces. Defaults to False.
+        tool_modules (Optional[Set[str]]): Set of built-in module names to load.
+            Available modules: 'calculation', 'log', 'system', 'ros'.
+            Defaults to all modules when None. Pass an empty set to disable all
+            built-in tools and use only custom tools — useful for purpose-built
+            agents where ROS introspection tools are not needed and token
+            efficiency is important.
+
+            Example::
+
+                # Disable all built-in tools, use only custom tools
+                agent = ROSA(ros_version=1, llm=llm, tool_modules=set())
+
+                # Load only the calculation module
+                agent = ROSA(ros_version=1, llm=llm, tool_modules={"calculation"})
 
     Attributes:
         chat_history (list): A list of messages representing the chat history.
@@ -93,7 +107,7 @@ class ROSA:
         streaming: bool = True,
         max_iterations: int = 100,
         return_intermediate_steps: bool = False,
-        tool_modules: Optional[set] = None,  # add this
+        tool_modules: Optional[Set[str]] = None,
     ):
         self.__chat_history = []
         self.__ros_version = ros_version
@@ -282,8 +296,18 @@ class ROSA:
         packages: Optional[list],
         tools: Optional[list],
         blacklist: Optional[list],
-        tool_modules: Optional[set],
+        tool_modules: Optional[Set[str]],
     ) -> ROSATools:
+        """Create a ROSATools object with the specified ROS version, tools, packages, blacklist,
+        and optional tool module selection.
+
+        :param ros_version: ROS version (1 or 2).
+        :param packages: List of Python packages containing LangChain tool functions.
+        :param tools: List of additional LangChain tool functions.
+        :param blacklist: List of tool names to exclude.
+        :param tool_modules: Set of built-in module names to load. Pass empty set to
+            disable all built-in modules.
+        """
         rosa_tools = ROSATools(ros_version, blacklist=blacklist, tool_modules=tool_modules)
         if tools:
             rosa_tools.add_tools(tools)

--- a/src/rosa/tools/__init__.py
+++ b/src/rosa/tools/__init__.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import inspect
+import warnings
 from functools import wraps
 from typing import Literal, List, Optional, Set
 
@@ -89,6 +90,16 @@ class ROSATools:
         self.__ros_version = ros_version
         self.__blacklist = blacklist
         self.__tool_modules = tool_modules if tool_modules is not None else DEFAULT_MODULES
+
+        # Warn about unknown module names
+        unknown = self.__tool_modules - ALL_MODULES
+        if unknown:
+            warnings.warn(
+                f"Unknown tool module(s): {unknown}. "
+                f"Available modules: {ALL_MODULES}",
+                UserWarning,
+                stacklevel=2,
+            )
 
         if "calculation" in self.__tool_modules:
             from . import calculation

--- a/src/rosa/tools/__init__.py
+++ b/src/rosa/tools/__init__.py
@@ -14,7 +14,7 @@
 
 import inspect
 from functools import wraps
-from typing import Literal, List, Optional
+from typing import Literal, List, Optional, Set
 
 from langchain.agents import Tool
 
@@ -62,31 +62,55 @@ def inject_blacklist(default_blacklist: List[str]):
     return decorator
 
 
+# All available built-in tool modules
+ALL_MODULES: Set[str] = {"calculation", "log", "system", "ros"}
+
+# Default: load all modules (preserves original behaviour)
+DEFAULT_MODULES: Set[str] = ALL_MODULES.copy()
+
+
 class ROSATools:
     def __init__(
-        self, ros_version: Literal[1, 2], blacklist: Optional[List[str]] = None
+        self,
+        ros_version: Literal[1, 2],
+        blacklist: Optional[List[str]] = None,
+        tool_modules: Optional[Set[str]] = None,
     ):
+        """
+        Initialize ROSATools.
+
+        :param ros_version: ROS version (1 or 2).
+        :param blacklist: List of tool names to exclude from the agent.
+        :param tool_modules: Set of built-in module names to load. Available modules:
+            'calculation', 'log', 'system', 'ros'. Defaults to all modules.
+            Pass an empty set to disable all built-in tools and use only custom tools.
+        """
         self.__tools: list = []
         self.__ros_version = ros_version
         self.__blacklist = blacklist
+        self.__tool_modules = tool_modules if tool_modules is not None else DEFAULT_MODULES
 
-        # Add the default tools
-        from . import calculation, log, system
+        if "calculation" in self.__tool_modules:
+            from . import calculation
+            self.__iterative_add(calculation)
 
-        self.__iterative_add(calculation)
-        self.__iterative_add(log)
-        self.__iterative_add(system)
+        if "log" in self.__tool_modules:
+            from . import log
+            self.__iterative_add(log)
 
-        if self.__ros_version == 1:
-            from . import ros1
+        if "system" in self.__tool_modules:
+            from . import system
+            self.__iterative_add(system)
 
-            self.__iterative_add(ros1, blacklist=blacklist)
-        elif self.__ros_version == 2:
-            from . import ros2
-
-            self.__iterative_add(ros2, blacklist=blacklist)
-        else:
-            raise ValueError("Invalid ROS version. Must be either 1 or 2.")
+        if "ros" in self.__tool_modules:
+            if self.__ros_version == 1:
+                from . import ros1
+                self.__iterative_add(ros1, blacklist=blacklist)
+            elif self.__ros_version == 2:
+                from . import ros2
+                self.__iterative_add(ros2, blacklist=blacklist)
+            else:
+                raise ValueError("Invalid ROS version. Must be either 1 or 2.")
 
     def get_tools(self) -> List[Tool]:
         return self.__tools
@@ -94,7 +118,6 @@ class ROSATools:
     def __add_tool(self, tool):
         if hasattr(tool, "name") and hasattr(tool, "func"):
             if self.__blacklist and "blacklist" in tool.func.__code__.co_varnames:
-                # Inject the blacklist into the tool function
                 tool.func = inject_blacklist(self.__blacklist)(tool.func)
             self.__tools.append(tool)
 
@@ -123,7 +146,7 @@ class ROSATools:
         """
         Add a single tool to the Tools object.
 
-        :param tools: A list of tools to add
+        :param tools: A list of tools to add.
         """
         for tool in tools:
             self.__add_tool(tool)

--- a/tests/test_rosa/tools/test_rosa_tools.py
+++ b/tests/test_rosa/tools/test_rosa_tools.py
@@ -105,6 +105,64 @@ class TestROSA2Tools(unittest.TestCase):
             tools = ROSATools(ros_version=1)
             self.assertIn(mock_ros2.return_value, tools.get_tools())
 
+class TestROSAToolModules(unittest.TestCase):
+    """Tests for the tool_modules parameter introduced to allow selective
+    loading of built-in ROSA tool modules."""
+
+    def test_empty_tool_modules_loads_no_builtin_tools(self):
+        """Passing tool_modules=set() should result in zero built-in tools."""
+        ros_version = int(os.getenv("ROS_VERSION", 1))
+        tools = ROSATools(ros_version=ros_version, tool_modules=set())
+        self.assertEqual(len(tools.get_tools()), 0)
+
+    def test_none_tool_modules_loads_all_builtin_tools(self):
+        """Passing tool_modules=None should load all built-in modules (default behaviour)."""
+        from src.rosa.tools import DEFAULT_MODULES, ALL_MODULES
+        self.assertEqual(DEFAULT_MODULES, ALL_MODULES)
+
+    def test_selective_tool_modules_loads_only_specified(self):
+        """Passing tool_modules={'calculation'} should load only the specified modules
+        and not load others."""
+        ros_version = int(os.getenv("ROS_VERSION", 1))
+        # With only calculation, we get some tools
+        tools_calc = ROSATools(ros_version=ros_version, tool_modules={"calculation"})
+        count_calc = len(tools_calc.get_tools())
+        # With empty set, we get zero tools
+        tools_empty = ROSATools(ros_version=ros_version, tool_modules=set())
+        count_empty = len(tools_empty.get_tools())
+        # With all modules, we get more tools than with just calculation
+        tools_all = ROSATools(ros_version=ros_version, tool_modules=None)
+        count_all = len(tools_all.get_tools())
+        # Selective loading should give more than empty but less than all
+        self.assertEqual(count_empty, 0)
+        self.assertGreater(count_calc, count_empty)
+        self.assertLess(count_calc, count_all)
+
+    def test_unknown_module_raises_warning(self):
+        """Passing an unknown module name should raise a UserWarning."""
+        ros_version = int(os.getenv("ROS_VERSION", 1))
+        with self.assertWarns(UserWarning):
+            ROSATools(ros_version=ros_version, tool_modules={"unknown_module"})
+
+    def test_tool_modules_defaults_to_all(self):
+        """Not passing tool_modules should default to all built-in modules."""
+        from src.rosa.tools import DEFAULT_MODULES, ALL_MODULES
+        ros_version = int(os.getenv("ROS_VERSION", 1))
+        tools = ROSATools(ros_version=ros_version, tool_modules=None)
+        self.assertEqual(tools._ROSATools__tool_modules, ALL_MODULES)
+
+    def test_custom_tools_work_with_empty_tool_modules(self):
+        """Custom tools should still be added when tool_modules=set()."""
+        @tool
+        def my_custom_tool() -> str:
+            """A custom tool."""
+            return "custom"
+
+        ros_version = int(os.getenv("ROS_VERSION", 1))
+        rosa_tools = ROSATools(ros_version=ros_version, tool_modules=set())
+        rosa_tools.add_tools([my_custom_tool])
+        self.assertEqual(len(rosa_tools.get_tools()), 1)
+        self.assertEqual(rosa_tools.get_tools()[0].name, "my_custom_tool")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Purpose
Add a `tool_modules` parameter to `ROSATools` and `ROSA` that allows selective loading of built-in tool modules. This enables purpose-built agents to disable unused ROS introspection tools, significantly reducing prompt token overhead.

## Proposed Changes
- [ADD] `tool_modules` parameter to `ROSATools.__init__` with full docstring, `ALL_MODULES`/`DEFAULT_MODULES` constants, selective module loading logic, and `UserWarning` for unknown module names
- [ADD] `tool_modules` parameter to `ROSA.__init__` and `_get_tools()` with updated class docstring and usage examples
- [ADD] `Set` to typing imports in `rosa.py`
- [ADD] Restored and updated `_get_tools()` docstring with new parameter documented
- [ADD] `TestROSAToolModules` test class with 6 tests covering: empty set, None default, selective loading, unknown module warning, default behaviour, and custom tools with empty modules

## Issues
No existing issue - proposing new feature based on real-world deployment need.

## Testing
All 6 new tests pass on ROS1 Noetic, Python 3.10.14, Jetson Orin NX hardware:
- TestROSAToolModules::test_custom_tools_work_with_empty_tool_modules PASSED
- TestROSAToolModules::test_empty_tool_modules_loads_no_builtin_tools PASSED
- TestROSAToolModules::test_none_tool_modules_loads_all_builtin_tools PASSED
- TestROSAToolModules::test_selective_tool_modules_loads_only_specified PASSED
- TestROSAToolModules::test_tool_modules_defaults_to_all PASSED
- TestROSAToolModules::test_unknown_module_raises_warning PASSED

Note: `TestROSATools::test_adds_default_tools` fails on the upstream `main` branch before our changes - confirmed pre-existing issue unrelated to this PR.

**Real-world impact:** Tested on ROS1 Noetic on Jetson Orin NX hardware. Disabling unused built-in modules reduced prompt tokens by **50-78% per query** (from ~10,000 to ~2,400-4,800 tokens), significantly reducing latency and API cost for production deployments.

## Usage:

### Disable all built-in tools - use only custom tools
agent = ROSA(ros_version=1, llm=llm, tool_packages=[my_tools], tool_modules=set())

### Load only specific built-in modules
agent = ROSA(ros_version=1, llm=llm, tool_modules={"calculation", "system"})

### Default behaviour unchanged
agent = ROSA(ros_version=1, llm=llm)

**Backwards compatible:** `tool_modules=None` (default) preserves existing behaviour exactly.